### PR TITLE
normalizing "parse" behavior

### DIFF
--- a/backbone-nested-models.js
+++ b/backbone-nested-models.js
@@ -60,6 +60,7 @@
                     val = val.toJSON()
                 }
 
+                if (options.parse) val = relation.parse(val, options);
                 relation.set(val, options);
 
                 return relation;


### PR DESCRIPTION
parse gets executed on related collections (within backbone), for related models we need to call parse on our own if the parse option is provided

This results inconsistent behavior when fetching data from a server and can be reproduced locally
```
var TestModel = Model.extend({
    defaults: {
        parsed: false,
    },
    parse(attr) {
        attr.parsed = true;
        return attr;
    }
});

var TestCollection = Collection.extend({
    model: TestModel
});

var RootModel = Model.extend({
    defaults: {
        testModel: null,
        testCollection: [],
    },
    relations: {
        testModel: TestModel,
        testCollection: TestCollection,
    },
});

var testInstance = new RootModel();
console.log(testInstance.toJSON()); // { testModel: { parsed: false }, testCollection: [] }

testInstance.set({
    testModel: {blub: "bla"},
    testCollection: [
        {blub: "bla2"},
        {blub: "bla3"}
    ]
}, {parse: true});

console.log(testInstance.toJSON()); // { testModel: { parsed: false, blub: 'bla' }, testCollection: [ { parsed: true, blub: 'bla2' }, { parsed: true, blub: 'bla3' } ] }
```